### PR TITLE
本提案は体験版の静的ページの前提を維持します

### DIFF
--- a/app.js
+++ b/app.js
@@ -1328,26 +1328,12 @@ function closeEditModal() {
     currentEditingId = null;
 }
 
-// ヘルプモーダルを表示
-function showHelpModal() {
-    document.getElementById('helpModal').style.display = 'flex';
-}
-
-// ヘルプモーダルを閉じる
-function closeHelpModal() {
-    document.getElementById('helpModal').style.display = 'none';
-}
-
 // モーダルの背景クリックで閉じる
 document.addEventListener('click', function(e) {
     const editModal = document.getElementById('editModal');
-    const helpModal = document.getElementById('helpModal');
     
     if (e.target === editModal) {
         closeEditModal();
-    }
-    if (e.target === helpModal) {
-        closeHelpModal();
     }
 });
 
@@ -1403,8 +1389,6 @@ document.addEventListener('keydown', function(e) {
         if (document.getElementById('editModal').style.display === 'flex') {
             closeEditModal();
         }
-        if (document.getElementById('helpModal').style.display === 'flex') {
-            closeHelpModal();
-        }
+        // ヘルプモーダルは外部リンク化のため廃止
     }
 });

--- a/index.html
+++ b/index.html
@@ -131,52 +131,13 @@
 
     <div class="toast" id="toast"></div>
 
-    <!-- フローティングヘルプボタン -->
-    <button onclick="showHelpModal()" class="floating-help-btn" data-tooltip="使い方・機能説明を表示">❓</button>
-
-    <!-- ヘルプモーダル -->
-    <div class="modal" id="helpModal" style="display: none;">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3>❓ ClipTuck の使い方</h3>
-                <button class="close-btn" onclick="closeHelpModal()">×</button>
-            </div>
-            <div class="modal-body">
-                <div class="help-content">
-                    <h4>📚 基本的な使い方</h4>
-                    <ul>
-                        <li><strong>ブックマーク保存:</strong> URL、タイトル、タグ、説明を入力して「保存」をクリック</li>
-                        <li><strong>検索:</strong> 検索欄にキーワードを入力してリアルタイム検索</li>
-                        <li><strong>フィルタ:</strong> タグ、ドメイン、期間でブックマークを絞り込み</li>
-                        <li><strong>アーカイブ:</strong> 📁ボタンでアーカイブ、📂ボタンでアンアーカイブ</li>
-                    </ul>
-                    
-                    <h4>🔖 ブックマークレット</h4>
-                    <p>「ブックマークレット」ボタンをクリックして表示されるボタンをブラウザのブックマークバーにドラッグ。任意のページで実行すると自動的にClipTuckに保存されます。</p>
-                    
-                    <h4>⚡ キーボードショートカット</h4>
-                    <ul>
-                        <li><kbd>Ctrl+S</kbd> / <kbd>Cmd+S</kbd>: ブックマーク保存</li>
-                        <li><kbd>Esc</kbd>: モーダル・ブックマークレット画面を閉じる</li>
-                    </ul>
-                    
-                    <h4>📊 データ管理</h4>
-                    <ul>
-                        <li><strong>エクスポート:</strong> すべてのデータをJSONファイルでバックアップ</li>
-                        <li><strong>インポート:</strong> JSONファイルから既存データに追加（重複は上書きされません）</li>
-                        <li><strong>グループ表示:</strong> ドメイン別・日付別でブックマークを整理</li>
-                        <li><strong>⚠️ 体験版制限:</strong> ブックマーク保存は最大50件まで（完全版はほぼ無制限）</li>
-                    </ul>
-                    
-                    <h4>🎯 選択機能</h4>
-                    <p>チェックボックスで複数のブックマークを選択し、一括削除が可能です。「全選択」「全解除」ボタンで効率的に操作できます。</p>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button class="btn-cancel" onclick="closeHelpModal()">閉じる</button>
-            </div>
-        </div>
-    </div>
+    <!-- フローティングヘルプボタン（外部リンク） -->
+    <a href="https://note.com/redcord/n/n394272c3c8e4"
+       class="floating-help-btn"
+       target="_blank"
+       rel="noopener noreferrer"
+       aria-label="ヘルプ（Note記事を開く）"
+       data-tooltip="使い方・機能説明（外部サイト）">❓</a>
 
     <!-- 編集モーダル -->
     <div class="modal" id="editModal" style="display: none;">

--- a/style.css
+++ b/style.css
@@ -744,27 +744,6 @@ body {
     text-shadow: 1px 1px 2px rgba(93, 78, 55, 0.5);
 }
 
-/* ヘルプボタン */
-.smart-btn.help-button {
-    background: linear-gradient(135deg, #6B9FCC 0%, #5A8AB8 100%);
-    color: var(--paper-bg);
-    border: 3px solid #3F6B9A;
-    font-weight: 700;
-    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
-    box-shadow:
-        0 4px 8px rgba(63, 107, 154, 0.4),
-        inset 0 2px 0 rgba(255, 255, 255, 0.3),
-        inset 0 -2px 0 rgba(0, 0, 0, 0.1);
-}
-
-.smart-btn.help-button:hover {
-    background: linear-gradient(135deg, #6B9FCC 0%, #5A8AB8 100%);
-    border-color: #5A8AB8;
-    transform: translateY(-2px);
-    box-shadow:
-        0 4px 8px rgba(63, 107, 154, 0.4),
-        inset 0 1px 0 rgba(255, 255, 255, 0.3);
-}
 
 /* 選択ボタン（青色） */
 .smart-btn.select-btn {
@@ -1285,6 +1264,9 @@ body {
     position: fixed;
     bottom: 30px;
     right: 30px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     width: 60px;
     height: 60px;
     border-radius: 50%;
@@ -1294,6 +1276,7 @@ body {
     font-size: 24px;
     font-weight: 700;
     cursor: pointer;
+    text-decoration: none;
     box-shadow: 
         0 6px 16px rgba(93, 78, 55, 0.3),
         inset 0 2px 0 rgba(248, 243, 231, 0.3);
@@ -1827,49 +1810,6 @@ select:disabled {
         inset 0 -1px 0 rgba(0, 0, 0, 0.1);
 }
 
-/* ヘルプモーダル専用スタイル */
-.help-content {
-    line-height: 1.6;
-}
-
-.help-content h4 {
-    margin: 20px 0 10px 0;
-    color: var(--primary-color);
-    font-size: 16px;
-    font-weight: 600;
-}
-
-.help-content h4:first-child {
-    margin-top: 0;
-}
-
-.help-content ul {
-    margin: 10px 0;
-    padding-left: 20px;
-}
-
-.help-content li {
-    margin: 8px 0;
-}
-
-.help-content strong {
-    color: var(--text-color);
-    font-weight: 600;
-}
-
-.help-content kbd {
-    background: var(--medium-gray);
-    border: 1px solid var(--border-color);
-    border-radius: 3px;
-    padding: 2px 6px;
-    font-size: 12px;
-    font-family: monospace;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.1);
-}
-
-.help-content p {
-    margin: 10px 0;
-}
 
 /* モーダルのレスポンシブ対応 */
 @media (max-width: 768px) {
@@ -1882,13 +1822,5 @@ select:disabled {
     .modal-body,
     .modal-footer {
         padding: 15px;
-    }
-    
-    .help-content h4 {
-        font-size: 15px;
-    }
-    
-    .help-content ul {
-        padding-left: 16px;
     }
 }


### PR DESCRIPTION
ヘルプボタンを外部リンク化し、ヘルプモーダルを削除。

- 右下ヘルプ→ Note記事へ新規タブ遷移
- ヘルプモーダルDOMを削除
- JSの showHelpModal/closeHelpModal と関連参照を削除
- ESC/背景クリックのヘルプ処理を整理
- アンカーでも円形ボタン表示できるよう CSS を調整
- 未使用のヘルプ用CSSを削除